### PR TITLE
Proposal to replace most of Robert's Rules with a protocol using git

### DIFF
--- a/Git_Rules_of_Order.md
+++ b/Git_Rules_of_Order.md
@@ -1,0 +1,69 @@
+# Robert's Rules of Order
+Problems Robert's Rules solves:
+Decisions were made by traveling to a central location and holding orderly meetings. Everything was done by speaking to other members of the group in real time. Nothing was asynchronous. Robert's Rules exists to bring order to these types of groups by defining
+
+* How order is kept.
+  * Who gets to speak when?
+  * What is required for a decision to become final?
+* How to make and keep an agenda
+  * Who gets to bring up what topics when?
+
+## Glossary
+
+### Defining
+Things which are immutable during the course of an invocation of the rules.
+
+* chair: The presiding officer of the meeting, generally the chapter President.
+
+### Protocol
+Things which are quantitative, logical, and asynchronous:
+
+* ballot: Voting in writing can take place if the issue being discussed is a sensitive matter and the chair or
+members wish the voting to be secret.
+* motion: The method used to place an issue, question, or decision in front of the members so it can be
+discussed and voted upon. Discussion on an issue to be decided is out of order unless an appropriate
+motion has been made.
+* second: Most motions need a second (that is, another member must agree that the question or issue
+should be discussed). This keeps items that are of interest to only one member from taking up time during
+a meeting.
+
+### Relational
+Things which are conversational, chronological:
+
+* floor: A member is considered to “have the floor” when the chair calls upon him or her to speak. In most
+cases, it is improper to interrupt someone who currently has the floor.
+* order: Comments or discussion presented by a member are “in order” if the chair has properly
+recognized the member and the comments made pertain to the issue being discussed. Likewise, the
+member is “out of order” if either of these two conditions is not met.
+* quorum: The number of members needed to be present to conduct business legally. This number is set
+in your chapter’s bylaws.
+
+### Irrelevant
+Things which may fit into one of the categories above but which are obsoleted by this protocol.
+
+* voice vote: The chair requests that members indicate their preference on the issue by responding “yes”
+or “no” when asked to do so. The chair decides, based on the voices, whether the “yes” or “no” votes
+were in the majority. The chair may ask for a show of hands if it is unclear by voice vote how members
+voted. 
+
+# Proposal to replace Robert's Rules
+
+* ballot: A ballot is a pull request. Pull requests may be opened at any time by any member of the board or organization, similar to how Robert's Rules states that attendees may bring up business not on the agenda.
+* motion: A motion is the act of opening a pull request.
+* second: A second is a quorum of approvals of the pull request by the board. The act of submitting or amending a
+pull request is an implicit vote for the measure by each pull request contributor.
+* floor: During board meetings, the floor is the right of a board member to speak. On a pull request, the floor is the right of board members and community members to engage in reasonable helpful discussion about an issue.
+
+## Pull Requests
+Pull requests serve as requests from a board member or the community to discuss an issue and make a decision. Pull requests can be opened at any time by any member of the community. Most pull requests will probably change policy or add files like minutes, resolutions, or guidelines for the community by modifying Markdown files stored in the [nonprofit-governance](https://github.com/nativesintech/nonprofit-governance) repository. Some changes, like adding information to the website, may be made in the form of code changes to other repositories.
+
+The board members and the community will discuss the issue publicly on the pull request in the form of requests for changes to the pull request, comments, and PR approvals.
+
+In the [nonprofit-governance](https://github.com/nativesintech/nonprofit-governance) repo, a vote is recorded by requiring all members of the Board group approve the PR. The measure is considered passed and any member of the board or the issuer of the pull request may merge the pull request and the issue is resolved.
+
+During board meetings, additional discussion can be made about each issue and board members may vote before the meeting or may wait until during the meeting to place their votes.
+
+In a departure from Robert's Rules, we will not provide a mechanism for anonymous voting at this time.
+
+## Vocal discussion
+Robert's Rules places many rules on the style and flow of vocal conversation during a session. We will delay implementing any of these or implementing a different protocol to guide how we have vocal discussions. The size of our meetings does not yet require such heavy-handed protocols.

--- a/README.md
+++ b/README.md
@@ -5,3 +5,6 @@ This repository records governance policy, meeting minutes, and other informatio
 The rules by which Natives In Tech governs itself. A by-law is a rule or law established by an organization or community to regulate itself, as allowed or provided for by some higher authority. The higher authority, generally a legislature or some other government body, establishes the degree of control that the by-laws may exercise. By-laws may be established by entities such as a business corporation, a neighborhood association, or depending on the jurisdiction, a municipality. [Find out more at Wikipedia.](https://en.wikipedia.org/wiki/By-law)
 
 [Read ours here.](Natives_In_Tech_Bylaws.md)
+
+## Issues and Voting
+We use pull requests for issues and voting. [See the protocol here.](Git_Rules_of_Order.md)


### PR DESCRIPTION
Robert's Rules of Order are old-fashioned, heavy-handed, and designed to solve many problems we don't have as a board who meets remotely and whose discussions are long-running and constant.

Here is my proposal to replace most of Robert's Rules with a git pull request-based protocol for proposing actions, discussing them, and voting.